### PR TITLE
docs: introduce MkDocs for documentation site

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,34 @@
+name: Deploy docs to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ 'v*' ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install mkdocs mkdocs-material mkdocstrings[python]
+      - name: Build site
+        run: mkdocs build --strict
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -2,7 +2,7 @@ name: Deploy docs to GitHub Pages
 
 on:
   push:
-    branches: [ main ]
+  branches: [ main, mkdoc ]
     tags: [ 'v*' ]
   workflow_dispatch:
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,11 @@ build/
 *.egg-info/
 .venv/
 
+# MkDocs build output and caches
+site/
+.cache/
+.mkdocs-cache/
+
 # Ignore apple macOS system files
 .DS_Store
 # Ignore Jupyter Notebook checkpoints
@@ -14,4 +19,14 @@ build/
 
 # Ignore VSCode settings
 .vscode/
+
+# common Python tooling artifacts
+.ruff_cache/
+.coverage
+coverage.xml
+htmlcov/
+.env
+env/
+venv/
+.python-version
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing
+
+## Dev setup
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+pip install -e .
+```
+
+## Lint & test
+
+```bash
+ruff check .
+black --check .
+pytest -q
+```
+
+## Docs: build & serve
+
+Install doc dependencies:
+
+```bash
+pip install mkdocs mkdocs-material mkdocstrings[python]
+```
+
+Build/serve locally (auto-reload):
+
+```bash
+mkdocs serve
+```
+
+Deploy (manual):
+
+```bash
+mkdocs gh-deploy --clean
+```
+
+We use NumPy-style docstrings for API reference via mkdocstrings.

--- a/README.md
+++ b/README.md
@@ -85,3 +85,28 @@ This package implements methods described in:
 While the paper above  used AEPsych (a Gaussian Process–based trial placer),
 `psyphy` integrates trial placement directly with the WPPM posterior (e.g. via InfoGain/EAVC),
 making the  adaptive trial placement model-aware.
+
+## Docs
+
+Build and preview the documentation locally:
+
+```bash
+# from repo root
+source .venv/bin/activate
+pip install mkdocs mkdocs-material 'mkdocstrings[python]'
+mkdocs serve
+```
+
+Build the static site:
+
+```bash
+mkdocs build
+```
+
+Deploy to GitHub Pages (manual):
+
+```bash
+mkdocs gh-deploy --clean
+```
+
+For contributors, see CONTRIBUTING.md for full doc guidelines and NumPy-style docstrings.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,20 @@
+# psyphy
+
+Psychophysical modeling and adaptive trial placement.
+
+## Install
+
+```bash
+# in your project root
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+## What is in psyphy?
+
+- Models: WPPM, priors, noise, task likelihoods
+- Inference: MAP, Langevin, Laplace
+- Posterior: wrappers and diagnostics
+- Trial placement: Placement strategies (acquisition functions) (e.g., grid, staircase, info gain)
+- Session: end-to-end orchestration of an experiment 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,4 +17,4 @@ pip install -e .
 - Inference: MAP, Langevin, Laplace
 - Posterior: wrappers and diagnostics
 - Trial placement: Placement strategies (acquisition functions) (e.g., grid, staircase, info gain)
-- Session: end-to-end orchestration of an experiment 
+- Session: end-to-end orchestration of an experiment

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,3 @@
+# API Reference
+
+::: psyphy

--- a/docs/reference/data.md
+++ b/docs/reference/data.md
@@ -1,0 +1,17 @@
+# Data
+
+## Package
+
+::: psyphy.data
+
+## Datasets
+
+::: psyphy.data.dataset
+
+## Transforms
+
+::: psyphy.data.transforms
+
+## I/O
+
+::: psyphy.data.io

--- a/docs/reference/data.md
+++ b/docs/reference/data.md
@@ -4,11 +4,11 @@
 
 ::: psyphy.data
 
-## Datasets
+## Data Containers for Response Data and Proposed Next Trials
 
 ::: psyphy.data.dataset
 
-## Transforms
+## Transforms (e.g., from RGB to model space)
 
 ::: psyphy.data.transforms
 

--- a/docs/reference/inference.md
+++ b/docs/reference/inference.md
@@ -1,0 +1,21 @@
+# Inference
+
+## Package
+
+::: psyphy.inference
+
+## Base
+
+::: psyphy.inference.base
+
+## MAP Optimizer
+
+::: psyphy.inference.map_optimizer
+
+## Langevin
+
+::: psyphy.inference.langevin
+
+## Laplace
+
+::: psyphy.inference.laplace

--- a/docs/reference/inference.md
+++ b/docs/reference/inference.md
@@ -12,10 +12,10 @@
 
 ::: psyphy.inference.map_optimizer
 
-## Langevin
+## Langevin Samplers
 
 ::: psyphy.inference.langevin
 
-## Laplace
+## Laplace Approximation
 
 ::: psyphy.inference.laplace

--- a/docs/reference/model.md
+++ b/docs/reference/model.md
@@ -4,7 +4,7 @@
 
 ::: psyphy.model
 
-## WPPM
+## Wishart Psyochophysical Process Model (WPPM)
 
 ::: psyphy.model.wppm
 

--- a/docs/reference/model.md
+++ b/docs/reference/model.md
@@ -1,0 +1,21 @@
+# Model
+
+## Package
+
+::: psyphy.model
+
+## WPPM
+
+::: psyphy.model.wppm
+
+## Priors
+
+::: psyphy.model.prior
+
+## Noise
+
+::: psyphy.model.noise
+
+## Tasks
+
+::: psyphy.model.task

--- a/docs/reference/overview.md
+++ b/docs/reference/overview.md
@@ -1,0 +1,3 @@
+# API Overview
+
+::: psyphy

--- a/docs/reference/posterior.md
+++ b/docs/reference/posterior.md
@@ -1,0 +1,13 @@
+# Posterior
+
+## Package
+
+::: psyphy.posterior
+
+## Core
+
+::: psyphy.posterior.posterior
+
+## Diagnostics
+
+::: psyphy.posterior.diagnostics

--- a/docs/reference/posterior.md
+++ b/docs/reference/posterior.md
@@ -4,7 +4,7 @@
 
 ::: psyphy.posterior
 
-## Core
+## Posterior Representation
 
 ::: psyphy.posterior.posterior
 

--- a/docs/reference/session.md
+++ b/docs/reference/session.md
@@ -1,0 +1,9 @@
+# Session
+
+## Package
+
+::: psyphy.session
+
+## Experiment Session
+
+::: psyphy.session.experiment_session

--- a/docs/reference/trial_placement.md
+++ b/docs/reference/trial_placement.md
@@ -1,0 +1,29 @@
+# Trial Placement
+
+## Package
+
+::: psyphy.trial_placement
+
+## Base
+
+::: psyphy.trial_placement.base
+
+## Grid
+
+::: psyphy.trial_placement.grid
+
+## Sobol
+
+::: psyphy.trial_placement.sobol
+
+## Staircase
+
+::: psyphy.trial_placement.staircase
+
+## Greedy MAP
+
+::: psyphy.trial_placement.greedy_map
+
+## Info Gain
+
+::: psyphy.trial_placement.info_gain

--- a/docs/reference/utils.md
+++ b/docs/reference/utils.md
@@ -1,0 +1,17 @@
+# Utils
+
+## Package
+
+::: psyphy.utils
+
+## RNG
+
+::: psyphy.utils.rng
+
+## Math
+
+::: psyphy.utils.math
+
+## Candidates
+
+::: psyphy.utils.candidates

--- a/docs/reference/utils.md
+++ b/docs/reference/utils.md
@@ -12,6 +12,6 @@
 
 ::: psyphy.utils.math
 
-## Candidates
+## Stimulus candidates
 
 ::: psyphy.utils.candidates

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,17 +2,45 @@
 
 ## Quick start
 
+
 ```python
-from psyphy import WPPM, Prior, OddityTask, MAPOptimizer
+import jax
+import jax.numpy as jnp
+import optax
 
-prior = Prior.default()
-model = WPPM(prior=prior)
-lik = OddityTask()
-opt = MAPOptimizer(model, lik)
-res = opt.fit(data=None)
-print(res)
+from psyphy.data.dataset import ResponseData
+from psyphy.model import WPPM, Prior, OddityTask, GaussianNoise
+from psyphy.inference.map_optimizer import MAPOptimizer
+from psyphy.trial_placement.grid import GridPlacement
+from psyphy.session.experiment_session import ExperimentSession
+
+# --- Setup model ---
+prior = Prior.default(input_dim=2)
+task = OddityTask()
+noise = GaussianNoise()
+model = WPPM(input_dim=2, prior=prior, task=task, noise=noise)
+
+# --- Inference engine ---
+inference = MAPOptimizer(steps=200)
+
+# --- Placement strategy ---
+placement = GridPlacement(grid_points=[(0,0)])  # MVP stub
+
+# --- Session orchestrator ---
+sess = ExperimentSession(model, inference, placement)
+
+# Initialize posterior (before any data)
+posterior = sess.initialize()
+
+# Collect data (simulated here)
+batch = sess.next_batch(batch_size=5)
+# subject_responses = run_trials(batch)   # user-defined
+# sess.data.add_batch(batch, subject_responses)
+
+# Update posterior with data
+posterior = sess.update()
+
+# Predict thresholds
+ellipse = posterior.predict_thresholds(reference=jnp.array([0.0, 0.0]))
+
 ```
-
-## CLI / Notebooks
-- Use JupyterLab for interactive exploration: `jupyter lab`
-- See examples you create under `examples/` as you build them out.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,18 @@
+# Usage
+
+## Quick start
+
+```python
+from psyphy import WPPM, Prior, OddityTask, MAPOptimizer
+
+prior = Prior.default()
+model = WPPM(prior=prior)
+lik = OddityTask()
+opt = MAPOptimizer(model, lik)
+res = opt.fit(data=None)
+print(res)
+```
+
+## CLI / Notebooks
+- Use JupyterLab for interactive exploration: `jupyter lab`
+- See examples you create under `examples/` as you build them out.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,53 @@
+site_name: psyphy
+site_description: Psychophysical modeling and adaptive trial placement
+site_url: https://hmd101.github.io/psyphy/
+repo_url: https://github.com/hmd101/psyphy
+repo_name: hmd101/psyphy
+
+theme:
+  name: material
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - content.code.copy
+    - toc.integrate
+  palette:
+    - scheme: default
+      primary: blue
+      accent: indigo
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: [src]
+          options:
+            docstring_style: numpy
+            show_source: true
+            show_root_toc_entry: false
+            separate_signature: true
+            inherited_members: true
+            members_order: source
+
+markdown_extensions:
+  - admonition
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight
+  - pymdownx.inlinehilite
+
+nav:
+  - Home: index.md
+  - Usage: usage.md
+  - Reference:
+      - Overview: reference/overview.md
+      - Data: reference/data.md
+      - Model: reference/model.md
+      - Inference: reference/inference.md
+      - Posterior: reference/posterior.md
+      - Trial Placement: reference/trial_placement.md
+      - Session: reference/session.md
+      - Utils: reference/utils.md


### PR DESCRIPTION
### Summary
This PR adds [MkDocs](https://www.mkdocs.org/) with the Material theme and mkdocstrings plugin to generate a browsable documentation site for the package.

### Details
- Added `mkdocs.yml` configuration.
- Created `docs/` directory with starter pages:
  - `index.md` (overview, installation instructions)
  - `usage.md` (quickstart examples)
  - `reference.md` (API reference via mkdocstrings).
- Integrated mkdocstrings with NumPy-style docstrings for automatic API documentation.
- Verified local build with `mkdocs serve`.

### Motivation
MkDocs provides:
- A clean, searchable documentation website.
- Automatic rendering of API docs from our existing docstrings.
- Easier onboarding for contributors and users.
- Ability to deploy documentation (e.g., via GitHub Pages).

### Next Steps
- Flesh out usage guides and examples.
- Add deployment workflow to publish docs automatically on merges to `main`.
